### PR TITLE
Automate readme translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@
 </p>
 
 <p align="center">
-  <a href="/docs/readme_fr.md">Français</a>
+  <a href="/docs/README_fr.md">Français</a>
   ·
-  <a href="/docs/readme_ja.md">简体中文</a>
+  <a href="/docs/README_ja.md">日本語</a>
   ·
-  <a href="/docs/readme_es.md">Español</a>
+  <a href="/docs/README_es.md">Español</a>
 </p>
 
 Mojichi, which comes from combination of the words 文字 (Moji) which means "Character" and 友達 (Tomodachi) "Friend", is a virtual compannion pet, with lots of customization and interaction features.
@@ -44,7 +44,7 @@ There are multiple included pets for you to choose:
             <strong>Pedrito</strong>
             <br>
             the goofiest cat around
-        </td>  
+        </td>
     </tr>
     <tr>
         <td><img src="https://github.com/JohnGolgota/tamagochi/assets/110570465/930f015b-16fc-462b-b950-fe7785255153">
@@ -52,7 +52,7 @@ There are multiple included pets for you to choose:
             <strong>Pedrito's deformed cousin</strong>
             <br>
             was born close to a nuclear plant was abbandoned so he has no name and everyone knows him as pedrito's cousin
-        </td>  
+        </td>
     </tr>
 </table>
 

--- a/docs/README_fr.md
+++ b/docs/README_fr.md
@@ -1,10 +1,10 @@
 <div align="center">
-    <h2>Kigoutchi</h2>
+    <h2>Mojichi</h2>
     <img src="https://github.com/JohnGolgota/tamagochi/assets/110570465/af16d452-b48c-4b89-bc19-2090cc00f69b" alt="repository's banner" width="350px" height="150px">
 </div>
 
 <div align="center">
-    <h2>Tu mascota virtual desarrollada en Rust</h2>
+    <h2>Votre animal de compagnie virtuel développé en Rust</h2>
 </div>
 
 <p align="center">
@@ -15,10 +15,7 @@
       <img alt="GitHub Contributors" src="https://img.shields.io/github/contributors/JohnGolgota/tamagochi" />
     </a>
     <a href="https://github.com/JohnGolgota/tamagochi">
-      <img alt="Build Status" src="https://github.com/JohnGolgota/tamagochi/workflows/Build/badge.svg?branchName=main">
-    </a>
-    <a href="https://github.com/JohnGolgota/tamagochi/actions">
-      <img alt="Tests Passing" src="https://github.com/JohnGolgota/tamagochi/workflows/Test/badge.svg?" />
+      <img alt="Build Status" src="https://github.com/JohnGolgota/tamagochi/actions/workflows/build_and_test.yml/badge.svg">
     </a>
     <a href="https://github.com/JohnGolgota/tamagochi/issues">
       <img alt="Issues" src="https://img.shields.io/github/issues/JohnGolgota/tamagochi?color=0088ff" />
@@ -29,40 +26,42 @@
 </p>
 
 <p align="center">
-  <a href="/docs/readme_fr.md">Français</a>
+  <a href="/docs/README_fr.md">Français</a>
   ·
-  <a href="/docs/readme_ja.md">简体中文</a>
+  <a href="/docs/README_ja.md">日本語</a>
   ·
-  <a href="/docs/readme_es.md">Español</a>
+  <a href="/docs/README_es.md">Español</a>
 </p>
 
-Kigoutchi, abreviatura de 記号 Kigou 友達 Tomodachi ("Amigo Símbolo") es una mascota de compañía virtual, con muchas funciones de personalización e interacción.
+Mojichi, qui vient de la combinaison des mots 文字 (Moji) qui signifie « Caractère » et 友達 (Tomodachi) « Ami », est un compagnon virtuel avec de nombreuses fonctionnalités de personnalisation et d'interaction.
 
-## Variantes de Kigoutchi
-Kigoutchi tiene muchas opciones de mascotas para que elijas, que incluyen:
+## Variantes
+Il existe plusieurs animaux inclus parmi lesquels vous pouvez choisir :
 <table>
     <tr>
         <td><img src="https://github.com/JohnGolgota/tamagochi/assets/110570465/f04bb93b-dcfa-4696-a9c1-d0ad389c08a6">
         <td>
-            - Pedrito
+            <strong>Pedrito</strong>
             <br>
-            El gato más silly que hay
-        </td>  
+            le chat le plus loufoque du coin
+        </td>
     </tr>
     <tr>
         <td><img src="https://github.com/JohnGolgota/tamagochi/assets/110570465/930f015b-16fc-462b-b950-fe7785255153">
         <td>
-            - El primo deforme de Pedrito
+            <strong>Le cousin déformé de Pedrito</strong>
             <br>
-            Nació cerca de una planta nuclear, fue abandonado, por lo que no tiene nombre y todos lo conocen como el primo de Pedrito
-        </td>  
+            est né près d'une centrale nucléaire et a été abandonné, il n'a donc pas de nom et tout le monde le connaît comme le cousin de Pedrito
+        </td>
     </tr>
 </table>
 
-## Estas son todas las cosas que puedes hacer con tu Kigoutchi
-- :poultry_leg:    Aliméntarlo con una amplia variedad de comidas
-- :raised_hand:    Acaríciarlo con tu.. mano virtual..
-- :soap:    Límpiarlo para que no este todo desagradable y apestoso, ya sabes
-- :skull:    Mátarlo de varias maneras
+Vous pouvez également créer votre propre animal ! :
 
+CETTE SECTION EST EN COURS (WIP)
 
+## Voici tout ce que vous pouvez faire avec votre Mojichi
+- :poultry_leg:    Le nourrir avec une grande variété d'aliments
+- :raised_hand:    Le caresser avec votre.. main virtuelle..
+- :soap:    Le nettoyer pour qu'il ne soit pas tout sale et puant, vous voyez
+- :skull:    Le tuer de différentes manières

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -1,10 +1,10 @@
 <div align="center">
-    <h2>Kigoutchi</h2>
+    <h2>Mojichi (文字ち)</h2>
     <img src="https://github.com/JohnGolgota/tamagochi/assets/110570465/af16d452-b48c-4b89-bc19-2090cc00f69b" alt="repository's banner" width="350px" height="150px">
 </div>
 
 <div align="center">
-    <h2>Votre animal de compagnie virtuel s'est développé à Rust</h2>
+    <h2>Rustで開発されたあなたの仮想ペット</h2>
 </div>
 
 <p align="center">
@@ -15,10 +15,7 @@
       <img alt="GitHub Contributors" src="https://img.shields.io/github/contributors/JohnGolgota/tamagochi" />
     </a>
     <a href="https://github.com/JohnGolgota/tamagochi">
-      <img alt="Build Status" src="https://github.com/JohnGolgota/tamagochi/workflows/Build/badge.svg?branchName=main">
-    </a>
-    <a href="https://github.com/JohnGolgota/tamagochi/actions">
-      <img alt="Tests Passing" src="https://github.com/JohnGolgota/tamagochi/workflows/Test/badge.svg?" />
+      <img alt="Build Status" src="https://github.com/JohnGolgota/tamagochi/actions/workflows/build_and_test.yml/badge.svg">
     </a>
     <a href="https://github.com/JohnGolgota/tamagochi/issues">
       <img alt="Issues" src="https://img.shields.io/github/issues/JohnGolgota/tamagochi?color=0088ff" />
@@ -29,40 +26,42 @@
 </p>
 
 <p align="center">
-  <a href="/docs/readme_fr.md">Français</a>
+  <a href="/docs/README_fr.md">Français</a>
   ·
-  <a href="/docs/readme_ja.md">简体中文</a>
+  <a href="/docs/README_ja.md">日本語</a>
   ·
-  <a href="/docs/readme_es.md">Español</a>
+  <a href="/docs/README_es.md">Español</a>
 </p>
 
-Kigoutchi, Abréviation pour 記号 Kigou 友達 Tomodachi ("Symbole d'ami") est un animal de compagnie virtuel, avec de nombreuses fonctions de personnalisation et d'interaction.
+Mojichi（文字ち）は、「文字」(Moji) と 「友達」(Tomodachi) を組み合わせた名前の仮想ペットです。豊富なカスタマイズ機能とインタラクション機能を備えています。
 
-## Variants de Kigoutchi
-Kigoutchi a de nombreuses options d'animaux de compagnie à choisir, qui incluent:
+## バリエーション
+選べるペットがいくつか用意されています：
 <table>
     <tr>
         <td><img src="https://github.com/JohnGolgota/tamagochi/assets/110570465/f04bb93b-dcfa-4696-a9c1-d0ad389c08a6">
         <td>
-            - Pedrito
+            <strong>Pedrito</strong>
             <br>
-            Le chat le plus idiot qui soit
-        </td>  
+            このあたりで一番おどけた猫
+        </td>
     </tr>
     <tr>
         <td><img src="https://github.com/JohnGolgota/tamagochi/assets/110570465/930f015b-16fc-462b-b950-fe7785255153">
         <td>
-            - Le cousin déformé de Pedrito
+            <strong>Pedritoの不気味な従兄弟</strong>
             <br>
-            Il est né près d'une centrale nucléaire, a été abandonné, donc il n'a pas de nom et tout le monde le connaît en tant que cousin de Pedrito
-        </td>  
+            原発の近くで生まれ、捨てられたため名前がありません。みんなからは「Pedritoの従兄弟」として知られています。
+        </td>
     </tr>
 </table>
 
-## Ce sont toutes les choses que vous pouvez faire avec votre kigoutchi
-- :poultry_leg:    Nourrir avec une grande variété de repas
-- :raised_hand:    Caressez-le avec votre .. main virtuelle ..
-- :soap:   Boigner pour que tout ne soit pas désagréable et puant, tu sais
-- :skull:    Matar de plusieurs manières
+自分だけのペットを作ることもできます！：
 
+このセクションは現在作成中 (WIP) です。
 
+## Mojichiでできること
+- :poultry_leg:    多種多様な食べ物を与える
+- :raised_hand:    あなたの…バーチャルな手で…撫でてあげる
+- :soap:    不潔で臭くならないように、きれいに掃除してあげる
+- :skull:    様々な方法で殺す


### PR DESCRIPTION
<!-- You don't need to delete these comments -->
# Change Details <!-- The details of the applied changes and the reasons -->

Cambio necesario porque tras la automatización de la traducción del README con Github Actions ([translate.yaml](https://github.com/JohnGolgota/tamagochi/.github/workflows/translate.yml)) (la cual pushee directo a main porque pereza, si) ahora los archivos quedan nombrados `docs/README_{lang_code}.md` en lugar de `docs/readme_{lang_code}.md`.

Ah y tambien cambié el link al README Japones, antes estaba en Chino jajajsjasha (gracias Gemini).

## Issues or Fixes <!-- Name and link of the issue to which this change request belongs, and other information such as mentions -->

## Before merging branches <!-- Some requirements before merging to prevent errors -->

- [ ] Reviewed by one or more developers on the team.
- [ ] Tests.<!-- Tested on another device before deploying it to the server -->